### PR TITLE
Introduce new StatementIdAlreadyExistsException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.2.0
 -----
 
+* Added `StatementIdAlreadyExistsException`.
 * Added `UnsupportedStatementVersionException`.
 
 0.1.1

--- a/src/StatementIdAlreadyExistsException.php
+++ b/src/StatementIdAlreadyExistsException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\XApi\Common\Exception;
+
+/**
+ * Statement id already exists exception.
+ *
+ * @author Jérôme Parmentier <jerome.parmentier@acensi.fr>
+ */
+class StatementIdAlreadyExistsException extends XApiException
+{
+    public function __construct($statementId, \Exception $previous = null)
+    {
+        parent::__construct(sprintf('A statement with ID "%s" already exists.', $statementId), 0, $previous);
+    }
+}


### PR DESCRIPTION
Prepare moving the check for existing statement to the storage layer.